### PR TITLE
feat: added a basic syntax highlighter

### DIFF
--- a/atlas77-vscode-ext/.vscodeignore
+++ b/atlas77-vscode-ext/.vscodeignore
@@ -1,0 +1,4 @@
+.vscode/**
+.vscode-test/**
+.gitignore
+vsc-extension-quickstart.md

--- a/atlas77-vscode-ext/CHANGELOG.md
+++ b/atlas77-vscode-ext/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+All notable changes to the "atlas77-vscode-ext" extension will be documented in this file.
+
+Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [Unreleased]
+
+- Initial release

--- a/atlas77-vscode-ext/README.md
+++ b/atlas77-vscode-ext/README.md
@@ -1,0 +1,65 @@
+# atlas77-vscode-ext README
+
+This is the README for your extension "atlas77-vscode-ext". After writing up a brief description, we recommend including the following sections.
+
+## Features
+
+Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
+
+For example if there is an image subfolder under your extension project workspace:
+
+\!\[feature X\]\(images/feature-x.png\)
+
+> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+
+## Requirements
+
+If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+
+## Extension Settings
+
+Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
+
+For example:
+
+This extension contributes the following settings:
+
+* `myExtension.enable`: Enable/disable this extension.
+* `myExtension.thing`: Set to `blah` to do something.
+
+## Known Issues
+
+Calling out known issues can help limit users opening duplicate issues against your extension.
+
+## Release Notes
+
+Users appreciate release notes as you update your extension.
+
+### 1.0.0
+
+Initial release of ...
+
+### 1.0.1
+
+Fixed issue #.
+
+### 1.1.0
+
+Added features X, Y, and Z.
+
+---
+
+## Working with Markdown
+
+You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
+
+* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux).
+* Toggle preview (`Shift+Cmd+V` on macOS or `Shift+Ctrl+V` on Windows and Linux).
+* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets.
+
+## For more information
+
+* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
+* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
+
+**Enjoy!**

--- a/atlas77-vscode-ext/language-configuration.json
+++ b/atlas77-vscode-ext/language-configuration.json
@@ -1,0 +1,30 @@
+{
+    "comments": {
+        // symbol used for single line comment. Remove this entry if your language does not support line comments
+        "lineComment": "//",
+        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
+        "blockComment": [ "/*", "*/" ]
+    },
+    // symbols used as brackets
+    "brackets": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    // symbols that are auto closed when typing
+    "autoClosingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ],
+    // symbols that can be used to surround a selection
+    "surroundingPairs": [
+        ["{", "}"],
+        ["[", "]"],
+        ["(", ")"],
+        ["\"", "\""],
+        ["'", "'"]
+    ]
+}

--- a/atlas77-vscode-ext/package.json
+++ b/atlas77-vscode-ext/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "atlas77-vscode-ext",
+  "displayName": "atlas77-vscode-ext",
+  "description": "Syntax highlighting for the Atlas77 programming language",
+  "version": "0.0.1",
+  "engines": {
+    "vscode": "^1.116.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [{
+      "id": "atlas",
+      "aliases": ["Atlas77", "atlas"],
+      "extensions": [".atlas"],
+      "configuration": "./language-configuration.json"
+    }],
+    "grammars": [{
+      "language": "atlas",
+      "scopeName": "source.atlas",
+      "path": "./syntaxes/atlas.tmLanguage.json"
+    }]
+  }
+}

--- a/atlas77-vscode-ext/syntaxes/atlas.tmLanguage.json
+++ b/atlas77-vscode-ext/syntaxes/atlas.tmLanguage.json
@@ -1,0 +1,149 @@
+{
+	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+	"name": "Atlas77",
+	"patterns": [
+		{
+			"include": "#keywords"
+		},
+		{
+			"include": "#strings"
+		},
+		{
+			"include": "#comments"
+		},
+		{
+			"include": "#functions"
+		},
+		{
+			"include": "#punctuation"
+		},
+		{
+			"include": "#numbers"
+		}
+	],
+	"repository": {
+		"keywords": {
+			"patterns": [
+				{
+					"name": "keyword.control.atlas",
+					"match": "\\b(?:u?int(?:8|16|32|64)|import|let|while|fun|struct|public|extern|const|if|as|return|this|else|bool|true|false|union|null|delete|this|namespace|private|where|concept|operator|when|then|comptime|str|char|unit)\\b"
+				}
+			]
+		},
+		"strings": {
+			"name": "string.quoted.double.atlas",
+			"begin": "\"",
+			"end": "\"",
+			"patterns": [
+				{
+					"name": "constant.character.escape.atlas",
+					"match": "\\\\."
+				}
+			]
+		},
+		"comments": {
+			"patterns": [
+				{
+					"name": "comment.line.atlas",
+					"match": "//.*"
+				},
+				{
+					"name": "comment.block.atlas",
+					"match": "/\\*.*\\*/"
+				}
+			]
+		},
+		"punctuation": {
+			"patterns": [
+				{
+					"name": "punctuation.separator.double-colon.atlas",
+					"match": "::"
+				},
+				{
+					"name": "punctuation.separator.colon.atlas",
+					"match": ":"
+				},
+				{
+					"name": "punctuation.separator.comma.atlas",
+					"match": ","
+				},
+				{
+					"name": "punctuation.access.dot.atlas",
+					"match": "\\."
+				},
+				{
+					"name": "punctuation.terminator.semicolon.atlas",
+					"match": ";"
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"name": "constant.numeric.float.atlas",
+					"match": "\\b(\\d+(?:_\\d+)*\\.\\d+(?:_\\d+)*(?:[eE][+-]?\\d+(?:_\\d+)*)?)([uUlL]+)?\\b",
+					"captures": {
+						"1": {
+							"name": "constant.numeric.float.atlas"
+						},
+						"2": {
+							"name": "storage.type.numeric-suffix.atlas"
+						}
+					}
+				},
+				{
+					"name": "constant.numeric.float.leading-dot.atlas",
+					"match": "\\b\\.\\d+(?:_\\d+)*(?:[eE][+-]?\\d+(?:_\\d+)*)?[fF]?\\b"
+				},
+				{
+					"name": "constant.numeric.hex.atlas",
+					"match": "\\b0x[0-9A-Fa-f]+(?:_[0-9A-Fa-f]+)*\\b"
+				},
+				{
+					"name": "constant.numeric.binary.atlas",
+					"match": "\\b0b[01]+(?:_[01]+)*\\b"
+				},
+				{
+					"name": "constant.numeric.octal.atlas",
+					"match": "\\b0o[0-7]+(?:_[0-7]+)*\\b"
+				},
+				{
+					"name": "constant.numeric.integer.atlas",
+					"match": "\\b(\\d+(?:_\\d+)*)([uUlL]+)?\\b",
+					"captures": {
+						"1": {
+							"name": "constant.numeric.integer.atlas"
+						},
+						"2": {
+							"name": "storage.type.numeric-suffix.atlas"
+						}
+					}
+				}
+			]
+		},
+		"functions": {
+			"patterns": [
+				{
+					"name": "meta.function-call.atlas",
+					"begin": "(?=[A-Za-z_][A-Za-z0-9_]*(::[A-Za-z_][A-Za-z0-9_]*)*\\s*\\()",
+					"end": "(?=\\()",
+					"patterns": [
+						{
+							"match": "[A-Za-z_][A-Za-z0-9_]*(?=::)",
+							"name": "entity.name.namespace.atlas"
+						},
+						{
+							"match": "::",
+							"name": "punctuation.separator.double-colon.atlas"
+						},
+						{
+							"match": "[A-Za-z_][A-Za-z0-9_]*",
+							"name": "entity.name.function.atlas"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "source.atlas"
+}

--- a/atlas77-vscode-ext/vsc-extension-quickstart.md
+++ b/atlas77-vscode-ext/vsc-extension-quickstart.md
@@ -1,0 +1,29 @@
+# Welcome to your VS Code Extension
+
+## What's in the folder
+
+* This folder contains all of the files necessary for your extension.
+* `package.json` - this is the manifest file in which you declare your language support and define the location of the grammar file that has been copied into your extension.
+* `syntaxes/atlas.tmLanguage.json` - this is the Text mate grammar file that is used for tokenization.
+* `language-configuration.json` - this is the language configuration, defining the tokens that are used for comments and brackets.
+
+## Get up and running straight away
+
+* Make sure the language configuration settings in `language-configuration.json` are accurate.
+* Press `F5` to open a new window with your extension loaded.
+* Create a new file with a file name suffix matching your language.
+* Verify that syntax highlighting works and that the language configuration settings are working.
+
+## Make changes
+
+* You can relaunch the extension from the debug toolbar after making changes to the files listed above.
+* You can also reload (`Ctrl+R` or `Cmd+R` on Mac) the VS Code window with your extension to load your changes.
+
+## Add more language features
+
+* To add features such as IntelliSense, hovers and validators check out the VS Code extenders documentation at https://code.visualstudio.com/api/language-extensions/overview
+
+## Install your extension
+
+* To start using your extension with Visual Studio Code copy it into the `<user home>/.vscode/extensions` folder and restart Code.
+* To share your extension with the world, read on https://code.visualstudio.com/api/working-with-extensions/publishing-extension about publishing an extension.


### PR DESCRIPTION
## Basic syntax highlighter
This PR adds a basic vscode extension, adding support for highlighting .atlas files.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup/refactoring

## Additional notes

<img width="773" height="572" alt="image" src="https://github.com/user-attachments/assets/9454c386-7b5d-43f4-9023-9e3c8a48d774" />
